### PR TITLE
Update grid colors and labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # Order Grid Heatmap
 
-This repository contains a simple Leaflet demo that draws 1×1 km grid cells only for locations where orders exist. Each cell is colored according to the sum of orders that fall inside it (0–1 green, 1–3 yellow, 3+ red). The sample data includes a single order; add more points in the `orders` array inside `index.html`.
+This repository contains a simple Leaflet demo that draws 1×1 km grid cells only for locations where orders exist. Each cell is colored based on the sum of orders in that cell:
+
+* 0–1 green
+* 1–2 yellow
+* 2–3 orange
+* 3–4 pink
+* 4+ red
+
+Values displayed on each grid are rounded to two decimals and shown with a `%` sign. The sample data includes a single order; add more points in the `orders` array inside `index.html`.

--- a/index.html
+++ b/index.html
@@ -26,14 +26,6 @@
         { lat: 28.459, lng: 77.026, value: 2 } // sample order
       ];
 
-      orders.forEach(function (o) {
-        L.circleMarker([o.lat, o.lng], {
-          radius: 4,
-          color: 'blue',
-          fillColor: 'blue',
-          fillOpacity: 1
-        }).bindPopup('Value: ' + o.value).addTo(map);
-      });
 
       var gridLayer = L.layerGroup().addTo(map);
 
@@ -59,7 +51,18 @@
           var cell = cells[key];
           if (cell.sum <= 0) return;
 
-          var color = cell.sum > 3 ? 'red' : cell.sum > 1 ? 'yellow' : 'green';
+          var color;
+          if (cell.sum > 4) {
+            color = 'red';
+          } else if (cell.sum > 3) {
+            color = 'pink';
+          } else if (cell.sum > 2) {
+            color = 'orange';
+          } else if (cell.sum > 1) {
+            color = 'yellow';
+          } else {
+            color = 'green';
+          }
           var rect = L.rectangle([[cell.lat, cell.lng], [cell.lat + latStep, cell.lng + lonStep]], {
             color: '#555',
             weight: 1,
@@ -67,7 +70,8 @@
             fillOpacity: 0.5
           }).addTo(gridLayer);
 
-          rect.bindTooltip(String(cell.sum), { className: 'grid-label' });
+          var valueText = cell.sum.toFixed(2) + '%';
+          rect.bindTooltip(valueText, { className: 'grid-label' });
         });
       }
 


### PR DESCRIPTION
## Summary
- drop marker dots for orders
- adjust color ranges for 0–4+ values
- show grid values with two decimals and a `%` sign
- document new color scheme in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847e2ef2b7c8322abb9b212c57c244f